### PR TITLE
correct typo in comment

### DIFF
--- a/flexible-featured-posts-widget.php
+++ b/flexible-featured-posts-widget.php
@@ -21,7 +21,7 @@ GNU General Public License for more details.
 
 */
 
-/* exist if directly accessed */
+/* exit if directly accessed */
 if( ! defined( 'ABSPATH' ) ) exit;
 
 /* define variable for path to this plugin file. */


### PR DESCRIPTION
Just musing a learner might be momentarily confused by the typo 'exist' for 'exit', hence this request.

Elsewhere: in inc/widget.php line 11 you have a comment where 'classesname' could be a typo ('classname'), introducing the function ffpw_flexible_featured_post(). But since multiple class names can be added in the function, personally I like it as it is.
