### PR TITLE
replace old constructor with new

### DIFF
--- a/inc/widget.php
+++ b/inc/widget.php
@@ -12,7 +12,7 @@ class FFPW_Flexible_Featured_Post extends WP_Widget {
 	*/
 	function ffpw_flexible_featured_post() {
 	
-		$this->WP_Widget(
+		parent::__construct(
 			'ffpw_flexible_featured_post',
 			__( 'Flexible Featured Post Widget', 'flexible-featured-post-widget' ),
 			array(


### PR DESCRIPTION
Observed the plugin triggers the error notice added in WP 4.3 regarding php constructors, the one that starts '
( ! ) Notice: The called constructor method for WP_Widget is <strong>deprecated</strong> since version 4.3.0! Use <pre>__construct()</pre> instead.'

I looked at [this post on make](https://make.wordpress.org/core/2015/07/02/deprecating-php4-style-constructors-in-wordpress-4-3/)

php sez: "[call to parent::__construct() within the child constructor is required](http://php.net/manual/en/language.oop5.decon.php#language.oop5.decon.constructor) "
