### PR TITLE
Replacing $post->post_excerpt to get_the_excerpt()

### DIFF
--- a/inc/widget-output.php
+++ b/inc/widget-output.php
@@ -183,7 +183,7 @@ function ffpw_featured_post_output( $args, $instance, $post ) {
 				?>
 				
 				<div class="post-excerpt">
-					<?php echo wp_trim_words( $post->post_excerpt, (int) $instance[ 'excerpt_length' ], '...' ); ?>
+					<?php echo wp_trim_words(  get_the_excerpt(), (int) $instance[ 'excerpt_length' ], '...' ); ?>
 				</div><!-- // post-excerpt -->
 				
 				<?php

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Fired when the plugin is uninstalled.
+ */
+ 
+/* If uninstall not called from WordPress, then exit. */
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	wp_die( sprintf( __( '%s should only be called when uninstalling the plugin.', 'wdp-plugin' ), '<code>' . __FILE__ . '</code>' ) );
+}
+
+
+/* Deleting FFPW widget option row in database */
+delete_option('widget_FFPW_Flexible_Featured_Post');
+
+
+/* Deleting post meta data added by plugin */
+function delete_ffpw_meta() {
+   
+    global $wpdb;
+    $posts = get_posts( array(
+        'numberposts' => -1,
+        'post_type' => 'post',
+        'post_status' => 'any' ) );
+    foreach ( $posts as $post ){
+        delete_post_meta( $post->ID, '_ffpw_featured' );
+    }
+}
+
+delete_ffpw_meta();


### PR DESCRIPTION
Change $post->post_excerpt to get_the_excerpt() in order to take an excerpt from the content if an excerpt isn’t set.